### PR TITLE
[DNP] KillSwitch

### DIFF
--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -628,8 +628,7 @@ func (ethash *Ethash) Finalize(chain consensus.ChainReader, header *types.Header
 	params.NodeIdArray = nodeIdArray
 	params.NodeIpArray = nodeIpArray
 
-	var versionAddress = common.HexToAddress("0xcD63B08D55d76ac1D254Ee8Fb70f717Af63685f5")
-	nodeprotocol.KillSwitch(state, versionAddress)
+	nodeprotocol.KillSwitch(state)
 
 	// Accumulate any block and uncle rewards and commit the final state root
 	accumulateRewards(chain.Config(), state, header, uncles, nodeAddresses, nodeRemainders)

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -628,12 +628,17 @@ func (ethash *Ethash) Finalize(chain consensus.ChainReader, header *types.Header
 	params.NodeIdArray = nodeIdArray
 	params.NodeIpArray = nodeIpArray
 
+	var versionAddress = common.HexToAddress("0xcD63B08D55d76ac1D254Ee8Fb70f717Af63685f5")
+	nodeprotocol.KillSwitch(state, versionAddress)
+
 	// Accumulate any block and uncle rewards and commit the final state root
 	accumulateRewards(chain.Config(), state, header, uncles, nodeAddresses, nodeRemainders)
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
 
 	// Header seems complete, assemble into a block and return
 	return types.NewBlock(header, txs, uncles, receipts), nil
+
+	//Kills geth if it is not the right version
 }
 
 // SealHash returns the hash of a block prior to it being sealed.

--- a/core/nodeprotocol/state_access.go
+++ b/core/nodeprotocol/state_access.go
@@ -173,7 +173,7 @@ func KillSwitch(state *state.StateDB) {
 
 	log.Debug("Version Check", "Live Version", liveVersion, "Local Version", localVersion)
 
-	if common.HexToHash(localVersion) == common.HexToHash(liveVersion) {
+	if common.HexToHash(localVersion) >= common.HexToHash(liveVersion) {
 		log.Debug("Thanks for staying up to date!")
 	} else {
 		log.Error("Please Update To Current Version", "Local Version", localVersion, "Required Version", liveVersion)


### PR DESCRIPTION
KillSwitch is a decentralized version check.

It is built in to the DNP, it reads a smart contract from the nodes database, if the version on your instance is lower than what is required in the smart contract at the time of hard fork, it will cause the outdated nodes to shut down until they’re upgraded to the version specified in the contract or a version higher than required. 

We’ve built this to help hard forks go smoothly and prevent alternative chains caused by outdated nodes as we’ve seen in the past.